### PR TITLE
Allow PHP 7.3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-msi-inventory-sample-data-venia-pwa",
     "description": "N/A",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.2.0|~7.3.0",
         "magento/framework": "*",
         "magento/module-catalog-sample-data-venia": "dev-master",
         "magento/module-msi-inventory-sample-data":"*",


### PR DESCRIPTION
Magento 2.3 is now expected to support PHP 7.3, but we have found in magento/pwa-studio#1550 that the Venia sample data modules won't install in that environment. This line in composer.json may be the culprit, at least for this module.

### Related
https://github.com/zetlen/module-tax-sample-data-venia/pull/1 is the same edit for the `module-tax-sample-data-venia` module.
https://github.com/PMET-public/module-configurable-sample-data-venia/pull/2 is the same edit for the `module-configurable-sample-data-venia` module.